### PR TITLE
added OpenMapTiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Software Alternatives
 | Phone OS          | Android, iOS              | [Firefox OS](https://www.mozilla.org/en-US/firefox/os/)    |
 | Browser           | Chrome                    | [Firefox](https://www.mozilla.org/en-US/firefox/new/)      |
 | Search Engine     | Google                    | [DuckDuckGo](https://duckduckgo.com/)                      |
+| Maps              | Google Maps               | [OpenMapTiles](https://openmaptiles.org/) (self-hosted)    |
 | Social Network    | Facebook                  | ?                                                          |
 | Microblogging     | Twitter                   | ?                                                          |
 | Cloud Storage     | Dropbox, Google Drive     | ?                                                          |


### PR DESCRIPTION
added OpenMapTiles, which can server vector/raster tiles/WMS services and can be self-hosted or even hosted off-line